### PR TITLE
Fixed txid for Segwit Transactions

### DIFF
--- a/abcd/bitcoin/cache/Cache.cpp
+++ b/abcd/bitcoin/cache/Cache.cpp
@@ -124,7 +124,7 @@ Cache::loadLegacy(const std::string &path)
                 height = 0;
 
             txids.insert(txid);
-            txs.insert(tx);
+            txs.insert(tx, txid);
             txs.confirmed(txid, height, timestamp);
         }
     }

--- a/abcd/bitcoin/cache/TxCache.cpp
+++ b/abcd/bitcoin/cache/TxCache.cpp
@@ -471,12 +471,14 @@ TxCache::drop(const std::string &txid, time_t now)
 }
 
 bool
-TxCache::insert(const bc::transaction_type &tx)
+TxCache::insert(const bc::transaction_type &tx, std::string txid)
 {
     std::unique_lock<std::mutex> lock(mutex_);
 
     // Do not stomp existing tx's:
-    auto txid = bc::encode_hash(bc::hash_transaction(tx));
+    if (txid == "")
+        txid = bc::encode_hash(bc::hash_transaction(tx));
+
     if (txs_.find(txid) == txs_.end())
     {
         txs_[txid] = tx;

--- a/abcd/bitcoin/cache/TxCache.hpp
+++ b/abcd/bitcoin/cache/TxCache.hpp
@@ -172,7 +172,7 @@ public:
      * @return true if the callback should be fired.
      */
     bool
-    insert(const bc::transaction_type &tx);
+    insert(const bc::transaction_type &tx, std::string txid="");
 
     /**
      * Mark a transaction as confirmed.

--- a/abcd/bitcoin/network/TxUpdater.cpp
+++ b/abcd/bitcoin/network/TxUpdater.cpp
@@ -579,7 +579,7 @@ TxUpdater::fetchTx(const std::string &txid, IBitcoinConnection *bc)
         ABC_DebugLog("%s: tx %s fetched", uri.c_str(), txid.c_str());
         wipTxids_.erase(txid);
 
-        cache_.txs.insert(tx);
+        cache_.txs.insert(tx, txid);
         cache_.addresses.update();
         cacheDirty = true;
         cache_.servers.serverScoreUp(uri);

--- a/abcd/bitcoin/spend/Spend.cpp
+++ b/abcd/bitcoin/spend/Spend.cpp
@@ -223,7 +223,7 @@ Spend::saveTx(DataSlice rawTx, std::string &txidOut)
     auto balance = wallet_.addresses.balance(info);
 
     // Update the transaction cache:
-    wallet_.cache.txs.insert(tx);
+    wallet_.cache.txs.insert(tx, info.txid);
     wallet_.cache.addresses.updateSpend(info);
     wallet_.cache.save().log(); // Failure is fine
 

--- a/abcd/bitcoin/spend/Sweep.cpp
+++ b/abcd/bitcoin/spend/Sweep.cpp
@@ -95,7 +95,7 @@ sweepSend(Wallet &wallet,
     ABC_CHECK(wallet.txs.save(meta, balance, info.fee));
 
     // Update the transaction cache:
-    wallet.cache.txs.insert(tx);
+    wallet.cache.txs.insert(tx, info.txid);
     wallet.cache.addresses.updateSpend(info);
     wallet.cache.save().log(); // Failure is fine
 


### PR DESCRIPTION
When using the function `bc::hash_transaction`, there is a second optional param for the sighash type, and the default is `all`, but for segwit tx's it should be `anyone_can_pay`.

So instead of trying to get the txid using the function, we get it from the txid inside the metadata or from the electrum servers.
Only if we never got it, then we will try to calculate it the old way.